### PR TITLE
feat: add nginx.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY . .
 RUN yarn build
 
 FROM nginx:alpine
+COPY nginx.conf /etc/nginx/nginx.conf
 WORKDIR /usr/share/nginx/html
 COPY --from=builder /app/dist .
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ docker build -t speechgpt .
 ```
 2. Run the container.
 ```bash
-docker run -d -p 8080:80 --name=speechgpt speechgpt
+docker run -d -p 8080:8080 --name=speechgpt speechgpt
 ```
 3. Visit `http://localhost:8080/`.
 4. Enjoy!

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -74,7 +74,7 @@ docker build -t speechgpt .
 ```
 2. 运行容器
 ```bash
-docker run -d -p 8080:80 --name=speechgpt speechgpt
+docker run -d -p 8080:8080 --name=speechgpt speechgpt
 ```
 3. 访问 `http://localhost:8080/`
 4. 尽情享用！

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,20 @@
+worker_processes 1;
+events {
+    worker_connections 1024;
+}
+http {
+    include mime.types;
+    default_type application/octet-stream;
+    sendfile on;
+    keepalive_timeout 65;
+    gzip on;
+    server {
+        listen 8080;
+        server_name localhost;
+        location / {
+            root /usr/share/nginx/html;
+            index index.html index.htm;
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}


### PR DESCRIPTION
在我部署这个项目到自己的Google Cloud过程中，发现容器无法启动并在环境变量PORT=8080定义的端口上监听。

为了解决此问题，我们需要保住我们的Nginx服务器在Docker容器中监听正确的端口。
可以通过在Nginx配置文件中设置端口和在Dockerfile中添加相应的端口映射来实现这一点。
内容如nginx.conf

然后再稍微修改一下Dockerfile，将nginx.conf文件复制到Nginx容器的/etc/nginx/目录中，从而覆盖默认的Nginx配置。

完成这些更改后，重新构建和推送Docker镜像。顺利解决由于容器无法在正确端口上启动和监听而导致的部署失败问题。
本地构建Docker的端口再稍微做一下修改，即可在服务器和本地上正常运行。