### PR TITLE
Settings in the start

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,7 +21,7 @@ function Home() {
   const { speech, setSpeech, voice, setVoice } = useGlobalStore();
   const { sessions, addSession, setCurrentSessionId, currentSessionId } = useSessionStore();
 
-  const [openSetting, setOpenSetting] = useState<boolean>(false);
+  const [openSetting, setOpenSetting] = useState<boolean>(true);
   const [openAbout, setOpenAbout] = useState<boolean>(false);
 
   const notifyDict = {


### PR DESCRIPTION
Issue #83 

Added settings in the starting of the page so that we can load API key. By doing so we can ensure every use can add openAI key first before accessing the SpeechGPT.