### PR TITLE
fix: `temperature` is invalid

### DIFF
--- a/src/apis/openai.ts
+++ b/src/apis/openai.ts
@@ -3,6 +3,7 @@ export default async function sendRequest(
   openaiApiKey: string,
   openaiHost: string,
   openaiModel: string,
+  temperature: number,
   callback: (data: any) => void
 ) {
   const requestOptions = {
@@ -14,6 +15,7 @@ export default async function sendRequest(
     body: JSON.stringify({
       model: openaiModel || 'gpt-3.5-turbo',
       messages: messages,
+      temperature: temperature,
     }),
   };
 

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -231,6 +231,7 @@ const Content: React.FC<ContentProps> = ({ notify }) => {
       const openaiApiModel = existEnvironmentVariable('OPENAI_MODEL')
         ? getEnvironmentVariable('OPENAI_MODEL')
         : key.openaiModel;
+      const temperature = chat.temperature;
 
       if (existEnvironmentVariable('ACCESS_CODE')) {
         const accessCode = getEnvironmentVariable('ACCESS_CODE');
@@ -246,6 +247,7 @@ const Content: React.FC<ContentProps> = ({ notify }) => {
         openaiApiKey,
         openaiApiHost,
         openaiApiModel,
+        temperature,
         (data: any) => {
           setStatus('idle');
           if (data) {


### PR DESCRIPTION
`temperature` in chat setting is invalid. This parameter has NEVER been sent with openai API. I fixed the bug by adding an  argument to function `sendRequest` and puttiing it into `body`.